### PR TITLE
[feat] adding support for cli and refactoring the existing modules to include types

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -441,14 +441,14 @@ files = [
 
 [[package]]
 name = "lightning-utilities"
-version = "0.7.0"
+version = "0.7.1"
 description = "PyTorch Lightning Sample project."
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "lightning-utilities-0.7.0.tar.gz", hash = "sha256:959638922fe127239915a465fceb4e19469238335436bc3d4fadc13881743856"},
-    {file = "lightning_utilities-0.7.0-py3-none-any.whl", hash = "sha256:7f449504e432e80cef0775f2095a8a38f059b2f3e460499e74c71683930916f0"},
+    {file = "lightning-utilities-0.7.1.tar.gz", hash = "sha256:9748a5466490d6e45c2df60c1ee77ff37a1a660ea6313bc0832ab7317a081cef"},
+    {file = "lightning_utilities-0.7.1-py3-none-any.whl", hash = "sha256:a7c58e67831c17712736e38e8ad5b81dbf64184ce28684a502e896ecca939b67"},
 ]
 
 [package.dependencies]
@@ -459,6 +459,7 @@ typing-extensions = "*"
 cli = ["fire"]
 docs = ["sphinx (>=4.0,<5.0)"]
 test = ["coverage (==6.5.0)"]
+typing = ["mypy (>=1.0.0)"]
 
 [[package]]
 name = "markdown-it-py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,7 +111,7 @@ authors = ["vivekkhimani <vivekkhimani07@gmail.com>"]
 license = "GNU General Public License v3"
 readme = "README.md"
 homepage = "https://torchfl.readthedocs.io/en/latest/"
-repository = "https://github.com/vivekkhimani/torchfl"
+repository = "https://github.com/torchfl-org/torchfl"
 documentation = "https://torchfl.readthedocs.io/en/latest/"
 keywords = ["federated-learning", "pytorch", "pytorch-lightning", "torchfl"]
 classifiers=[
@@ -138,6 +138,11 @@ torchvision = "~0.14"
 pytorch-lightning = "~1.9"
 pytest = "^7.2.1"
 
+[tool.poetry.urls]
+"Issue Tracker" = "https://github.com/torchfl-org/torchfl/issues"
+
+[tool.poetry.scripts]
+torchfl = "torchfl.cli:main"
 
 [build-system]
 requires = ["poetry-core"]

--- a/torchfl/cli.py
+++ b/torchfl/cli.py
@@ -41,6 +41,7 @@ def cli_parser() -> Namespace:
     datamodule: _ArgumentGroup = parser.add_argument_group("datamodule")
     model: _ArgumentGroup = parser.add_argument_group("model")
     optimizer: _ArgumentGroup = parser.add_argument_group("optimizer")
+    parser.add_argument_group("trainer")
     federated: _ArgumentGroup = parser.add_argument_group("federated learning")
 
     # general args
@@ -141,25 +142,18 @@ def cli_parser() -> Namespace:
     # NOTE: PyTorch Lightning has fancy features for optimizers configuration, but we don't support them via CLI or YAML configs.
     # We can explore adding them in the future.
 
+    # trainer args
+    ## FIXME - add arguments for the trainer
+
     # federated args
     federated.add_argument(
-        "--num_workers",
+        "--num_agents",
         type=int,
         default=10,
-        help="number of workers for federated learning.",
+        help="number of agents for federated learning.",
     )
-    federated.add_argument(
-        "--worker_bs",
-        type=int,
-        default=10,
-        help="batch size of the dataset for workers training locally.",
-    )
-    federated.add_argument(
-        "--worker_ep",
-        type=int,
-        default=5,
-        help="number of epochs for the workers training locally.",
-    )
+    federated.add_argument("--global_epochs", type=int, default=10)
+    federated.add_argument("--local_epochs", type=int, default=5)
     federated.add_argument(
         "--iid",
         action="store_true",
@@ -171,6 +165,19 @@ def cli_parser() -> Namespace:
         default=2,
         help="max number of classes held by each niid agent. lower the number, more measure of non-iidness.",
     )
+    federated.add_argument("--local_test_split", type=float, default=0.1)
+    federated.add_argument("--local_train_bs", type=int, default=10)
+    federated.add_argument("--local_test_bs", type=int, default=10)
+    federated.add_argument(
+        "--sampling_method", type=str, default="random"
+    )  # FIXME: add choices here
+    federated.add_argument("--sampling_ratio", type=float, default=0.1)
+    federated.add_argument(
+        "--agent_type", type=str, default="v1"
+    )  # FIXME: add choices here
+    federated.add_argument(
+        "--aggregation_type", type=str, default="fedavg"
+    )  # FIXME: add choices here
 
     args = parser.parse_args()
     return args

--- a/torchfl/cli.py
+++ b/torchfl/cli.py
@@ -1,11 +1,33 @@
 #!/usr/bin/env python
 
 """Console script for torchfl."""
-from argparse import ArgumentParser, Namespace, _ArgumentGroup
+from argparse import (
+    Action,
+    ArgumentError,
+    ArgumentParser,
+    Namespace,
+    _ArgumentGroup,
+)
 from sys import exit
 
 from torchfl import __version__
-from torchfl.compatibility import DATASETS
+from torchfl.compatibility import TORCHFL_DIR
+from torchfl.datamodules.types import DATASET_GROUPS_MAP
+
+
+class DatasetNameSanitizer(Action):
+    def __init__(self, option_strings, dest, nargs=None, **kwargs):
+        if nargs is not None:
+            raise ValueError("nargs not allowed")
+        super().__init__(option_strings, dest, **kwargs)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        if values not in DATASET_GROUPS_MAP[namespace.dataset_group]:
+            raise ArgumentError(
+                namespace.dataset_name,
+                f"Invalid dataset name: {values}. Supported: {str(DATASET_GROUPS_MAP[namespace.dataset_group])}",
+            )
+        setattr(namespace, self.dest, values)
 
 
 def cli_parser() -> Namespace:
@@ -14,43 +36,79 @@ def cli_parser() -> Namespace:
     Returns:
         Namespace: Namespace object from argparse
     """
-    parser = ArgumentParser()
+    parser = ArgumentParser(prog="torchfl", description="torchfl CLI")
     general: _ArgumentGroup = parser.add_argument_group("general")
-    parser.add_argument_group("datamodule")
+    datamodule: _ArgumentGroup = parser.add_argument_group("datamodule")
     parser.add_argument_group("model")
     federated: _ArgumentGroup = parser.add_argument_group("federated learning")
 
     # general args
     general.add_argument(
-        "--version", action="version", version=f"torchfl {__version__}"
+        "--version", action="version", version=f"%(prog)s {__version__}"
     )
     general.add_argument(
         "--experiment_name",
         type=str,
-        default="torchfl_experiment",
+        required=True,
         help="name of the experiment.",
     )
     general.add_argument(
         "--experiment_version",
         type=float,
         default=0.1,
-        help="version of the experiment.",
-    )
-
-    general.add_argument(
-        "--dataset",
-        type=str,
-        default="mnist",
-        help=f"name of the dataset to be used. Supported: {DATASETS}",
-    )
-    general.add_argument(
-        "--test_bs",
-        type=int,
-        default=128,
-        help="batch size used for the testing dataset.",
+        help="version of the experiment. Default: 0.1",
     )
 
     # datamodule args
+    datamodule.add_argument(
+        "--data_dir",
+        type=str,
+        help=f"path to store the downloaded data-related files. Default: {TORCHFL_DIR}",
+        default=TORCHFL_DIR,
+    )
+    datamodule.add_argument(
+        "--dataset_group",
+        type=str,
+        choices=DATASET_GROUPS_MAP.keys(),
+        help="name of the dataset group.",
+    )
+    datamodule.add_argument(
+        "--dataset_name",
+        type=str,
+        action=DatasetNameSanitizer,
+        help="name of the dataset (should belong to a data group).",
+    )
+    datamodule.add_argument(
+        "--validation_split",
+        type=float,
+        help="validation split ratio. Default: 0.1",
+        default=0.1,
+    )
+    datamodule.add_argument(
+        "--train_bs",
+        type=int,
+        help="batch size used for the training dataset. Default: 128",
+        default=128,
+    )
+    datamodule.add_argument(
+        "--validation_bs",
+        type=int,
+        help="batch size used for the validation dataset. Default: 1",
+        default=1,
+    )
+    datamodule.add_argument(
+        "--test_bs",
+        type=int,
+        help="batch size used for the testing dataset. Default: 1",
+        default=1,
+    )
+    datamodule.add_argument(
+        "--predict_bs",
+        type=int,
+        help="batch size used for the prediction dataset. Default: 1",
+        default=1,
+    )
+    # NOTE: we can't support the following args as of now: train_transforms, val_transforms, test_transforms, predict_transforms
 
     # model args
 

--- a/torchfl/cli.py
+++ b/torchfl/cli.py
@@ -4,6 +4,7 @@
 from argparse import ArgumentParser, Namespace, _ArgumentGroup
 from sys import exit
 
+from torchfl import __version__
 from torchfl.compatibility import DATASETS
 
 
@@ -14,8 +15,44 @@ def cli_parser() -> Namespace:
         Namespace: Namespace object from argparse
     """
     parser = ArgumentParser()
-    federated: _ArgumentGroup = parser.add_argument_group("federated learning")
     general: _ArgumentGroup = parser.add_argument_group("general")
+    parser.add_argument_group("datamodule")
+    parser.add_argument_group("model")
+    federated: _ArgumentGroup = parser.add_argument_group("federated learning")
+
+    # general args
+    general.add_argument(
+        "--version", action="version", version=f"torchfl {__version__}"
+    )
+    general.add_argument(
+        "--experiment_name",
+        type=str,
+        default="torchfl_experiment",
+        help="name of the experiment.",
+    )
+    general.add_argument(
+        "--experiment_version",
+        type=float,
+        default=0.1,
+        help="version of the experiment.",
+    )
+
+    general.add_argument(
+        "--dataset",
+        type=str,
+        default="mnist",
+        help=f"name of the dataset to be used. Supported: {DATASETS}",
+    )
+    general.add_argument(
+        "--test_bs",
+        type=int,
+        default=128,
+        help="batch size used for the testing dataset.",
+    )
+
+    # datamodule args
+
+    # model args
 
     # federated args
     federated.add_argument(
@@ -48,20 +85,6 @@ def cli_parser() -> Namespace:
         help="max number of classes held by each niid agent. lower the number, more measure of non-iidness.",
     )
 
-    # general args
-    general.add_argument(
-        "--dataset",
-        type=str,
-        default="mnist",
-        help=f"name of the dataset to be used. Supported: {DATASETS}",
-    )
-    general.add_argument(
-        "--test_bs",
-        type=int,
-        default=128,
-        help="batch size used for the testing dataset.",
-    )
-
     args = parser.parse_args()
     return args
 
@@ -70,7 +93,7 @@ def main():
     """Console script for torchfl."""
     args = cli_parser()
 
-    print("Arguments: " + str(args._))
+    print("Arguments: " + str(args))
     print("Replace this message by putting your code into " "torchfl.cli.main")
     return 0
 

--- a/torchfl/cli.py
+++ b/torchfl/cli.py
@@ -39,7 +39,8 @@ def cli_parser() -> Namespace:
     parser = ArgumentParser(prog="torchfl", description="torchfl CLI")
     general: _ArgumentGroup = parser.add_argument_group("general")
     datamodule: _ArgumentGroup = parser.add_argument_group("datamodule")
-    parser.add_argument_group("model")
+    model: _ArgumentGroup = parser.add_argument_group("model")
+    optimizer: _ArgumentGroup = parser.add_argument_group("optimizer")
     federated: _ArgumentGroup = parser.add_argument_group("federated learning")
 
     # general args
@@ -58,6 +59,7 @@ def cli_parser() -> Namespace:
         default=0.1,
         help="version of the experiment. Default: 0.1",
     )
+    general.add_argument("-v", "--verbose", action="store_true")
 
     # datamodule args
     datamodule.add_argument(
@@ -111,6 +113,33 @@ def cli_parser() -> Namespace:
     # NOTE: we can't support the following args as of now: train_transforms, val_transforms, test_transforms, predict_transforms
 
     # model args
+    model.add_argument(
+        "--model_name",
+        type=str,
+        required=True,
+        help="name of the model.",
+    )
+    # FIXME: Write sanitizer validation functions for all of the following arguments
+    model.add_argument("--num_classes", type=int, help="number of classes.")
+    model.add_argument("--num_channels", type=int, help="number of channels.")
+    model.add_argument(
+        "--activation_fn", type=str, help="activation function name."
+    )
+    model.add_argument("--pretrained", action="store_false")
+    model.add_argument("--feature_extract", action="store_false")
+
+    # optimizer args
+    # FIXME: Write sanitizer validation functions for all of the following arguments
+    optimizer.add_argument(
+        "--optimizer_name",
+        type=str,
+        required=True,
+        help="name of the optimizer.",
+    )
+    optimizer.add_argument("--lr", type=float, help="learning rate.")
+    # NOTE: Optimizers support many more arguments. We can't support all of them in CLI, but we will add support for them in YAML configs.
+    # NOTE: PyTorch Lightning has fancy features for optimizers configuration, but we don't support them via CLI or YAML configs.
+    # We can explore adding them in the future.
 
     # federated args
     federated.add_argument(

--- a/torchfl/cli.py
+++ b/torchfl/cli.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 """Console script for torchfl."""
+import sys
 from argparse import (
     Action,
     ArgumentError,
@@ -12,10 +13,17 @@ from sys import exit
 
 from torchfl import __version__
 from torchfl.compatibility import TORCHFL_DIR
+from torchfl.config_resolver import ConfigResolver
 from torchfl.datamodules.types import DATASET_GROUPS_MAP
+from torchfl.federated.types import (
+    AGENTS_TYPE,
+    AGGREGATORS_TYPE,
+    SAMPLERS_TYPE,
+)
 
 
 class DatasetNameSanitizer(Action):
+    # FIXME: move this sanitizer to ConfigResolver
     def __init__(self, option_strings, dest, nargs=None, **kwargs):
         if nargs is not None:
             raise ValueError("nargs not allowed")
@@ -41,7 +49,7 @@ def cli_parser() -> Namespace:
     datamodule: _ArgumentGroup = parser.add_argument_group("datamodule")
     model: _ArgumentGroup = parser.add_argument_group("model")
     optimizer: _ArgumentGroup = parser.add_argument_group("optimizer")
-    parser.add_argument_group("trainer")
+    parser.add_argument_group("pl_trainer")
     federated: _ArgumentGroup = parser.add_argument_group("federated learning")
 
     # general args
@@ -49,9 +57,15 @@ def cli_parser() -> Namespace:
         "--version", action="version", version=f"%(prog)s {__version__}"
     )
     general.add_argument(
+        "-c",
+        "--config",
+        type=str,
+        help="path to the config file to create a torchfl experiment. Overrides CLI args.",
+    )  # FIXME - overrides other args when this is provided.
+    general.add_argument(
         "--experiment_name",
         type=str,
-        required=True,
+        required=("--config" not in sys.argv),
         help="name of the experiment.",
     )
     general.add_argument(
@@ -117,7 +131,7 @@ def cli_parser() -> Namespace:
     model.add_argument(
         "--model_name",
         type=str,
-        required=True,
+        required=("--config" not in sys.argv),
         help="name of the model.",
     )
     # FIXME: Write sanitizer validation functions for all of the following arguments
@@ -134,7 +148,7 @@ def cli_parser() -> Namespace:
     optimizer.add_argument(
         "--optimizer_name",
         type=str,
-        required=True,
+        required=("--config" not in sys.argv),
         help="name of the optimizer.",
     )
     optimizer.add_argument("--lr", type=float, help="learning rate.")
@@ -147,13 +161,26 @@ def cli_parser() -> Namespace:
 
     # federated args
     federated.add_argument(
+        "--federated", action="store_true", help="enable federated learning."
+    )
+    federated.add_argument(
         "--num_agents",
         type=int,
         default=10,
         help="number of agents for federated learning.",
     )
-    federated.add_argument("--global_epochs", type=int, default=10)
-    federated.add_argument("--local_epochs", type=int, default=5)
+    federated.add_argument(
+        "--global_epochs",
+        type=int,
+        default=10,
+        help="number of global epochs.",
+    )
+    federated.add_argument(
+        "--local_epochs",
+        type=int,
+        default=5,
+        help="number of local epochs for individual agents.",
+    )
     federated.add_argument(
         "--iid",
         action="store_true",
@@ -165,30 +192,56 @@ def cli_parser() -> Namespace:
         default=2,
         help="max number of classes held by each niid agent. lower the number, more measure of non-iidness.",
     )
-    federated.add_argument("--local_test_split", type=float, default=0.1)
-    federated.add_argument("--local_train_bs", type=int, default=10)
-    federated.add_argument("--local_test_bs", type=int, default=10)
     federated.add_argument(
-        "--sampling_method", type=str, default="random"
-    )  # FIXME: add choices here
+        "--local_test_split",
+        type=float,
+        default=0.1,
+        help="test split ratio for individual agents.",
+    )
+    federated.add_argument(
+        "--local_train_bs",
+        type=int,
+        default=10,
+        help="local training batch size for individual agents.",
+    )
+    federated.add_argument(
+        "--local_test_bs",
+        type=int,
+        default=10,
+        help="local testing batch size for individual agents.",
+    )
+    federated.add_argument(
+        "--sampling_method",
+        type=str,
+        default="random",
+        choices=SAMPLERS_TYPE,
+        help="sampling method for selecting the agents.",
+    )
     federated.add_argument("--sampling_ratio", type=float, default=0.1)
     federated.add_argument(
-        "--agent_type", type=str, default="v1"
-    )  # FIXME: add choices here
+        "--agent_type",
+        type=str,
+        default="v1",
+        choices=AGENTS_TYPE,
+        help="type of agent to use for federated learning.",
+    )
     federated.add_argument(
-        "--aggregation_type", type=str, default="fedavg"
-    )  # FIXME: add choices here
+        "--aggregation_type",
+        type=str,
+        default="fedavg",
+        choices=AGGREGATORS_TYPE,
+        help="type of aggregation to use for federated learning.",
+    )
 
-    args = parser.parse_args()
-    return args
+    return parser.parse_args()
 
 
 def main():
     """Console script for torchfl."""
     args = cli_parser()
-
+    _ = ConfigResolver(args)
+    # FIXME - the config resolver should return a torchfl job which can be run here
     print("Arguments: " + str(args))
-    print("Replace this message by putting your code into " "torchfl.cli.main")
     return 0
 
 

--- a/torchfl/compatibility.py
+++ b/torchfl/compatibility.py
@@ -25,7 +25,6 @@ from torch.optim import (
 )
 
 TORCHFL_DIR: str = os.path.join(Path.home(), ".torchfl")
-DATASETS = ["mnist", "emnist_digits", "cifar10"]
 OPTIMIZERS = [
     "adadelta",
     "adagrad",
@@ -42,14 +41,6 @@ OPTIMIZERS = [
     "sgd",
 ]
 ACTIVATION_FUNCTIONS = ["tanh", "relu", "leakyrelu", "gelu"]
-
-
-class DATASETS_TYPE(enum.Enum):
-    """Enum class for the supported datasets."""
-
-    MNIST = "mnist"
-    EMNIST_DIGITS = "emnist_digits"
-    CIFAR10 = "cifar10"
 
 
 class OPTIMIZERS_TYPE(enum.Enum):

--- a/torchfl/config_resolver.py
+++ b/torchfl/config_resolver.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+
+"""Contains the implementation of the ConfigResolver class."""
+
+from argparse import Namespace
+
+
+class ConfigResolver:
+    def __init__(self, config: Namespace) -> None:
+        """Constructor
+
+        Args:
+            - config (Namespace): Namespace object from argparse
+        """
+        self.config = config

--- a/torchfl/datamodules/__init__.py
+++ b/torchfl/datamodules/__init__.py
@@ -2,4 +2,5 @@
 
 __author__ = """Vivek Khimani"""
 __email__ = "vivekkhimani07@gmail.com"
-__version__ = "0.1.0"
+__version__ = "0.9.0"
+__all__ = ["emnist", "cifar", "fashionmnist"]

--- a/torchfl/datamodules/cifar.py
+++ b/torchfl/datamodules/cifar.py
@@ -21,6 +21,7 @@ from torch.utils.data import DataLoader, Dataset, random_split
 from torchvision import transforms
 from torchvision.datasets import CIFAR10, CIFAR100
 
+np.random.seed(42)
 pl.seed_everything(42)
 
 ###################

--- a/torchfl/datamodules/cifar.py
+++ b/torchfl/datamodules/cifar.py
@@ -17,13 +17,10 @@ from typing import Any
 
 import numpy as np
 import pytorch_lightning as pl
-import torch
 from torch.utils.data import DataLoader, Dataset, random_split
 from torchvision import transforms
 from torchvision.datasets import CIFAR10, CIFAR100
 
-torch.manual_seed(42)
-np.random.seed(42)
 pl.seed_everything(42)
 
 ###################
@@ -334,7 +331,6 @@ class CIFARDataModule(pl.LightningDataModule):
         distribution: dict[int, np.ndarray] = {
             i: np.array([], dtype="int64") for i in range(num_workers)
         }
-        np.random.seed(42)
         while idx_shard:
             for i in range(num_workers):
                 rand_set: set[int] = set(

--- a/torchfl/datamodules/emnist.py
+++ b/torchfl/datamodules/emnist.py
@@ -17,13 +17,10 @@ from typing import Any
 
 import numpy as np
 import pytorch_lightning as pl
-import torch
 from torch.utils.data import DataLoader, Dataset, random_split
 from torchvision import transforms
 from torchvision.datasets import EMNIST
 
-torch.manual_seed(42)
-np.random.seed(42)
 pl.seed_everything(42)
 
 ###################
@@ -330,7 +327,6 @@ class EMNISTDataModule(pl.LightningDataModule):
         distribution: dict[int, np.ndarray] = {
             i: np.array([], dtype="int64") for i in range(num_workers)
         }
-        np.random.seed(42)
         while idx_shard:
             for i in range(num_workers):
                 rand_set: set[int] = set(

--- a/torchfl/datamodules/emnist.py
+++ b/torchfl/datamodules/emnist.py
@@ -21,6 +21,7 @@ from torch.utils.data import DataLoader, Dataset, random_split
 from torchvision import transforms
 from torchvision.datasets import EMNIST
 
+np.random.seed(42)
 pl.seed_everything(42)
 
 ###################

--- a/torchfl/datamodules/fashionmnist.py
+++ b/torchfl/datamodules/fashionmnist.py
@@ -18,6 +18,7 @@ from torch.utils.data import DataLoader, Dataset, random_split
 from torchvision import transforms
 from torchvision.datasets import FashionMNIST
 
+np.random.seed(42)
 pl.seed_everything(42)
 
 ###################

--- a/torchfl/datamodules/fashionmnist.py
+++ b/torchfl/datamodules/fashionmnist.py
@@ -14,13 +14,10 @@ from typing import Any
 
 import numpy as np
 import pytorch_lightning as pl
-import torch
 from torch.utils.data import DataLoader, Dataset, random_split
 from torchvision import transforms
 from torchvision.datasets import FashionMNIST
 
-torch.manual_seed(42)
-np.random.seed(42)
 pl.seed_everything(42)
 
 ###################
@@ -287,7 +284,6 @@ class FashionMNISTDataModule(pl.LightningDataModule):
         distribution: dict[int, np.ndarray] = {
             i: np.array([], dtype="int64") for i in range(num_workers)
         }
-        np.random.seed(42)
         while idx_shard:
             for i in range(num_workers):
                 rand_set: set[int] = set(

--- a/torchfl/datamodules/types.py
+++ b/torchfl/datamodules/types.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+
+"""Types used within the datamodules utilities."""
+
+import enum
+
+from torchfl.datamodules.cifar import (
+    SUPPORTED_DATASETS_TYPE as CIFAR_DATASETS_TYPE,
+)
+from torchfl.datamodules.cifar import CIFARDataModule
+from torchfl.datamodules.emnist import (
+    SUPPORTED_DATASETS_TYPE as EMNIST_DATASETS_TYPE,
+)
+from torchfl.datamodules.emnist import EMNISTDataModule
+from torchfl.datamodules.fashionmnist import (
+    SUPPORTED_DATASETS_TYPE as FASHIONMNIST_DATASETS_TYPE,
+)
+from torchfl.datamodules.fashionmnist import FashionMNISTDataModule
+from torchfl.utils import _get_enum_values
+
+EMNIST_DATASETS: list[str] = _get_enum_values(EMNIST_DATASETS_TYPE)
+CIFAR_DATASETS: list[str] = _get_enum_values(CIFAR_DATASETS_TYPE)
+FASHIONMNIST_DATASETS: list[str] = _get_enum_values(FASHIONMNIST_DATASETS_TYPE)
+
+DATASET_GROUPS_MAP: dict[str, list[str]] = {
+    "emnist": EMNIST_DATASETS,
+    "cifar": CIFAR_DATASETS,
+    "fashionmnist": FASHIONMNIST_DATASETS,
+}
+
+
+class DatasetGroupsEnum(enum.Enum):
+    EMNIST = EMNISTDataModule
+    CIFAR = CIFARDataModule
+    FASHIONMNIST = FashionMNISTDataModule
+
+
+DatasetGroupsType = EMNISTDataModule | CIFARDataModule | FashionMNISTDataModule

--- a/torchfl/federated/__init__.py
+++ b/torchfl/federated/__init__.py
@@ -2,4 +2,5 @@
 
 __author__ = """Vivek Khimani"""
 __email__ = "vivekkhimani07@gmail.com"
-__version__ = "0.1.5"
+__version__ = "0.9.0"
+__all__ = ["entrypoint", "fl_params"]

--- a/torchfl/federated/agents/__init__.py
+++ b/torchfl/federated/agents/__init__.py
@@ -2,4 +2,5 @@
 
 __author__ = """Vivek Khimani"""
 __email__ = "vivekkhimani07@gmail.com"
-__version__ = "0.1.5"
+__version__ = "0.9.0"
+__all__ = ["v1"]

--- a/torchfl/federated/aggregators/__init__.py
+++ b/torchfl/federated/aggregators/__init__.py
@@ -2,4 +2,5 @@
 
 __author__ = """Vivek Khimani"""
 __email__ = "vivekkhimani07@gmail.com"
-__version__ = "0.1.5"
+__version__ = "0.9.0"
+__all__ = ["fedavg"]

--- a/torchfl/federated/samplers/__init__.py
+++ b/torchfl/federated/samplers/__init__.py
@@ -2,4 +2,5 @@
 
 __author__ = """Vivek Khimani"""
 __email__ = "vivekkhimani07@gmail.com"
-__version__ = "0.1.0"
+__version__ = "0.9.0"
+__all__ = ["random"]

--- a/torchfl/federated/types.py
+++ b/torchfl/federated/types.py
@@ -38,3 +38,7 @@ class SamplersEnum(enum.Enum):
 AgentsType = BaseAgent | V1Agent
 AggregatorsType = BaseAggregator | FedAvgAggregator
 SamplersType = BaseSampler | RandomSampler
+
+AGENTS_TYPE = ["v1"]
+AGGREGATORS_TYPE = ["fedavg"]
+SAMPLERS_TYPE = ["random"]

--- a/torchfl/utils.py
+++ b/torchfl/utils.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+
+"""Utility functions used within the torchfl package."""
+
+from typing import Any
+
+
+def _get_enum_values(enum_class: Any) -> list[str]:
+    """Return a list of values of an enum class."""
+    return [x.value for x in enum_class._member_map_.values()]


### PR DESCRIPTION
- Adding support for CLI and YAML.
- YAML parsing run to trigger jobs from CLI.
- Refactoring the existing modules to include individual typed modules.
- Setting a foundation for models refactor and potentially get rid of the ```torchfl.models.core``` subpackages.